### PR TITLE
chore: Convert usage to async

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         .library(name: "GraphitiJSONScalar", targets: ["GraphitiJSONScalar"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/GraphQLSwift/GraphQL.git", "2.0.0" ..< "4.0.0"),
+        .package(url: "https://github.com/GraphQLSwift/GraphQL.git", "2.3.0" ..< "4.0.0"),
         .package(url: "https://github.com/GraphQLSwift/Graphiti.git", "1.11.0" ..< "3.0.0"),
     ],
     targets: [

--- a/Tests/GraphQLJSONScalarTests/JSONObjectTests.swift
+++ b/Tests/GraphQLJSONScalarTests/JSONObjectTests.swift
@@ -13,13 +13,13 @@ final class JSONObjectTests: XCTestCase {
     }
 
     /// should support serialization
-    func testSerialize() throws {
-        let result = try graphql(
+    func testSerialize() async throws {
+        let result = try await graphql(
             schema: schema,
             request: "{ rootValue }",
             rootValue: fixture,
             eventLoopGroup: group
-        ).wait()
+        )
 
         XCTAssertEqual(
             result.data?["rootValue"],
@@ -29,13 +29,13 @@ final class JSONObjectTests: XCTestCase {
     }
 
     /// should reject string value
-    func testSerialize_String() throws {
-        let result = try graphql(
+    func testSerialize_String() async throws {
+        let result = try await graphql(
             schema: schema,
             request: "{ rootValue }",
             rootValue: "foo",
             eventLoopGroup: group
-        ).wait()
+        )
 
         XCTAssertEqual(result.data?["rootValue"], .null)
         XCTAssertEqual(
@@ -45,13 +45,13 @@ final class JSONObjectTests: XCTestCase {
     }
 
     /// should reject array value
-    func testSerialize_Array() throws {
-        let result = try graphql(
+    func testSerialize_Array() async throws {
+        let result = try await graphql(
             schema: schema,
             request: "{ rootValue }",
             rootValue: [],
             eventLoopGroup: group
-        ).wait()
+        )
 
         XCTAssertEqual(result.data?["rootValue"], .null)
         XCTAssertEqual(
@@ -61,8 +61,8 @@ final class JSONObjectTests: XCTestCase {
     }
 
     /// should support parsing values
-    func testParseValue() throws {
-        let result = try graphql(
+    func testParseValue() async throws {
+        let result = try await graphql(
             schema: schema,
             request: """
             query($arg: JSONObject!) {
@@ -71,7 +71,7 @@ final class JSONObjectTests: XCTestCase {
             """,
             eventLoopGroup: group,
             variableValues: ["arg": fixture]
-        ).wait()
+        )
 
         XCTAssertEqual(
             result.data?["value"],
@@ -81,8 +81,8 @@ final class JSONObjectTests: XCTestCase {
     }
 
     /// should reject string value
-    func testParseValue_String() throws {
-        let result = try graphql(
+    func testParseValue_String() async throws {
+        let result = try await graphql(
             schema: schema,
             request: """
             query($arg: JSON!) {
@@ -91,7 +91,7 @@ final class JSONObjectTests: XCTestCase {
             """,
             eventLoopGroup: group,
             variableValues: ["arg": "foo"]
-        ).wait()
+        )
 
         XCTAssertEqual(result.data?["value"], nil)
         XCTAssertEqual(
@@ -101,8 +101,8 @@ final class JSONObjectTests: XCTestCase {
     }
 
     /// should reject array value
-    func testParseValue_Array() throws {
-        let result = try graphql(
+    func testParseValue_Array() async throws {
+        let result = try await graphql(
             schema: schema,
             request: """
             query($arg: JSON!) {
@@ -111,7 +111,7 @@ final class JSONObjectTests: XCTestCase {
             """,
             eventLoopGroup: group,
             variableValues: ["arg": []]
-        ).wait()
+        )
 
         XCTAssertEqual(result.data?["value"], nil)
         XCTAssertEqual(
@@ -121,8 +121,8 @@ final class JSONObjectTests: XCTestCase {
     }
 
     /// should support parsing literals
-    func testParseLiteral() throws {
-        let result = try graphql(
+    func testParseLiteral() async throws {
+        let result = try await graphql(
             schema: schema,
             request: """
             query {
@@ -148,7 +148,7 @@ final class JSONObjectTests: XCTestCase {
             }
             """,
             eventLoopGroup: group
-        ).wait()
+        )
 
         XCTAssertEqual(
             result.data?["value"],
@@ -158,8 +158,8 @@ final class JSONObjectTests: XCTestCase {
     }
 
     /// should reject string value
-    func testParseLiteral_String() throws {
-        let result = try graphql(
+    func testParseLiteral_String() async throws {
+        let result = try await graphql(
             schema: schema,
             request: """
             query {
@@ -167,7 +167,7 @@ final class JSONObjectTests: XCTestCase {
             }
             """,
             eventLoopGroup: group
-        ).wait()
+        )
 
         XCTAssertEqual(result.data?["value"], nil)
         XCTAssertEqual(
@@ -177,8 +177,8 @@ final class JSONObjectTests: XCTestCase {
     }
 
     /// should reject array literal
-    func testParseLiteral_Array() throws {
-        let result = try graphql(
+    func testParseLiteral_Array() async throws {
+        let result = try await graphql(
             schema: schema,
             request: """
             query {
@@ -186,7 +186,7 @@ final class JSONObjectTests: XCTestCase {
             }
             """,
             eventLoopGroup: group
-        ).wait()
+        )
 
         XCTAssertEqual(result.data?["value"], nil)
         XCTAssertEqual(

--- a/Tests/GraphitiJSONScalarTests/GraphitiJSONScalarTests.swift
+++ b/Tests/GraphitiJSONScalarTests/GraphitiJSONScalarTests.swift
@@ -90,57 +90,62 @@ class GraphitiJSONScalarTests: XCTestCase {
         try? self.group.syncShutdownGracefully()
     }
 
-    func testNullLiteral() throws {
+    func testNullLiteral() async throws {
+        let result = try await api.execute(
+            request: "{ nullLiteral }",
+            context: api.context,
+            on: group
+        )
         XCTAssertEqual(
-            try api.execute(
-                request: "{ nullLiteral }",
-                context: api.context,
-                on: group
-            ).wait(),
+            result,
             .init(data: ["nullLiteral": .null])
         )
     }
 
-    func testBoolLiteral() throws {
+    func testBoolLiteral() async throws {
+        let result = try await api.execute(
+            request: "{ boolLiteral }",
+            context: api.context,
+            on: group
+        )
         XCTAssertEqual(
-            try api.execute(
-                request: "{ boolLiteral }",
-                context: api.context,
-                on: group
-            ).wait(),
+            result,
             .init(data: ["boolLiteral": true])
         )
     }
 
-    func testNumberLiteral() throws {
+    func testNumberLiteral() async throws {
+        let result = try await api.execute(
+            request: "{ numberLiteral }",
+            context: api.context,
+            on: group
+        )
         XCTAssertEqual(
-            try api.execute(
-                request: "{ numberLiteral }",
-                context: api.context,
-                on: group
-            ).wait(),
+            result,
             .init(data: ["numberLiteral": 42])
         )
     }
 
-    func testStringLiteral() throws {
+    func testStringLiteral() async throws {
+        let result = try await api.execute(
+            request: "{ stringLiteral }",
+            context: api.context,
+            on: group
+        )
         XCTAssertEqual(
-            try api.execute(
-                request: "{ stringLiteral }",
-                context: api.context,
-                on: group
-            ).wait(),
+            result,
             .init(data: ["stringLiteral": "Fourty-two"])
         )
     }
 
-    func testArray() throws {
+    func testArray() async throws {
+        let result = try await api.execute(
+            request: "{ array }",
+            context: api.context,
+            on: group
+        )
         XCTAssertEqual(
-            try api.execute(
-                request: "{ array }",
-                context: api.context,
-                on: group
-            ).wait(),
+            result,
             .init(data: ["array": [
                 ["number": 42, "null": .null],
                 ["string": "Fourty-two", "null": .null],
@@ -148,13 +153,14 @@ class GraphitiJSONScalarTests: XCTestCase {
         )
     }
 
-    func testDictionary() throws {
+    func testDictionary() async throws {
+        let result = try await api.execute(
+            request: "{ dictionary }",
+            context: api.context,
+            on: group
+        )
         XCTAssertEqual(
-            try api.execute(
-                request: "{ dictionary }",
-                context: api.context,
-                on: group
-            ).wait(),
+            result,
             .init(data: [
                 "dictionary": [
                     "null": .null,
@@ -181,8 +187,8 @@ class GraphitiJSONScalarTests: XCTestCase {
     }
 
     /// should support parsing values
-    func testParseValue() throws {
-        let result = try api.execute(
+    func testParseValue() async throws {
+        let result = try await api.execute(
             request: """
             query($arg: JSON!) {
                 value(arg: $arg)
@@ -191,7 +197,7 @@ class GraphitiJSONScalarTests: XCTestCase {
             context: api.context,
             on: group,
             variables: ["arg": fixture]
-        ).wait()
+        )
 
         let value = try XCTUnwrap(result.data?["value"])
         try XCTAssertEqualIgnoringOrder(value, fixture)
@@ -199,8 +205,8 @@ class GraphitiJSONScalarTests: XCTestCase {
     }
 
     /// should support parsing literals
-    func testParseLiteral() throws {
-        let result = try api.execute(
+    func testParseLiteral() async throws {
+        let result = try await api.execute(
             request: """
             query {
                 value(
@@ -226,7 +232,7 @@ class GraphitiJSONScalarTests: XCTestCase {
             """,
             context: api.context,
             on: group
-        ).wait()
+        )
 
         let value = try XCTUnwrap(result.data?["value"])
         try XCTAssertEqualIgnoringOrder(value, fixture)
@@ -234,8 +240,8 @@ class GraphitiJSONScalarTests: XCTestCase {
     }
 
     /// should handle null literal
-    func testParseLiteral_Null() throws {
-        let result = try api.execute(
+    func testParseLiteral_Null() async throws {
+        let result = try await api.execute(
             request: """
             query {
                 value(arg: null)
@@ -243,7 +249,7 @@ class GraphitiJSONScalarTests: XCTestCase {
             """,
             context: api.context,
             on: group
-        ).wait()
+        )
 
         XCTAssertEqual(
             result.data?["value"],
@@ -253,8 +259,8 @@ class GraphitiJSONScalarTests: XCTestCase {
     }
 
     /// should handle list literal
-    func testParseLiteral_List() throws {
-        let result = try api.execute(
+    func testParseLiteral_List() async throws {
+        let result = try await api.execute(
             request: """
             query {
                 value(arg: [])
@@ -262,7 +268,7 @@ class GraphitiJSONScalarTests: XCTestCase {
             """,
             context: api.context,
             on: group
-        ).wait()
+        )
 
         XCTAssertEqual(
             result.data?["value"],
@@ -272,8 +278,8 @@ class GraphitiJSONScalarTests: XCTestCase {
     }
 
     /// should handle list literal
-    func testParseLiteral_Invalid() throws {
-        let result = try api.execute(
+    func testParseLiteral_Invalid() async throws {
+        let result = try await api.execute(
             request: """
             query {
                 value(arg: INVALID)
@@ -281,7 +287,7 @@ class GraphitiJSONScalarTests: XCTestCase {
             """,
             context: api.context,
             on: group
-        ).wait()
+        )
 
         XCTAssertEqual(result.data, nil)
 


### PR DESCRIPTION
This better aligns with GraphQL and Graphiti's transition toward being Swift Concurrency-native